### PR TITLE
fix execute_with_log so it doesnt get stuck if the log contains a blank line

### DIFF
--- a/bin/functions/execute_with_log.py
+++ b/bin/functions/execute_with_log.py
@@ -73,7 +73,9 @@ def execute(workload_result_file, command_lines):
     count = 100
     last_time=0
     log_file = open(workload_result_file, 'w')
-    while True:
+    # see http://stackoverflow.com/a/4417735/1442961
+    lines_iterator = iter(proc.stdout.readline, b"")
+    for line in lines_iterator:
         count += 1
         if count > 100 or time()-last_time>1: # refresh terminal size for 100 lines or each seconds
             count, last_time = 0, time()
@@ -81,14 +83,13 @@ def execute(workload_result_file, command_lines):
             width -= 1
 
         try:
-            line = proc.stdout.readline().rstrip()
+            line = line.rstrip()
             log_file.write(line+"\n")
             log_file.flush()
         except KeyboardInterrupt:
             proc.terminate()
             break
         line = line.decode('utf-8')
-        if not line: break
         line = replace_tab_to_space(line)
         #print "{Red}log=>{Color_Off}".format(**Color), line
         lline = line.lower()


### PR DESCRIPTION
The current version of `execute_with_log` stops reading from stdin when it finds a blank line.  The intention is to use that as a signal that there is nothing else to read -- but it breaks if there is ever a blank line in the log.  Instead, we need a better check for if the process is done (which there is thankfully a python utility for).

You can observe this yourself by trying this really simple program:

```scala
object Foo {
  def main(args: Array[String]): Unit = {
    println("HI")
    println("next line blank")
    println()
    println("more stuff")
    println()
    (0 until 1e5.toInt).foreach{idx => println(idx)}
  }
}
```

and then running with `bin/functions/execute_with_log.py foo.log scala Foo`.  Before this change, you will see the program get stuck at the first blank line.  And if you take a `jstack` of the java process, you'll see its stuck trying to write to its stdout:

```
   java.lang.Thread.State: RUNNABLE
        at java.io.FileOutputStream.writeBytes(Native Method)
        at java.io.FileOutputStream.write(FileOutputStream.java:326)
  ...
```

After the change, this example program logs normally.  Spark actually writes blank log lines occasionally, as part of its `FetchFailed` logging, eg. try:

```scala
    val exc = new FetchFailedException(null, 0, 0, 0, "message", null)
    val str = exc.toTaskEndReason.asInstanceOf[TaskFailedReason].toErrorString
    println("\"" + str + "\"")
    println(str.contains("\n"))
```

Maybe thats weird behavior from spark, but nonetheless the hibench script shouldn't get stuck at this point.  We've run into this as we've been trying to do testing on more nodes & testing w/ fault injection.

I'm not a python developer by any means, so maybe there is a more "pythonic" way to do this.