### PR TITLE
Fix yarn-site.xml parsing

### DIFF
--- a/bin/functions/load-config.py
+++ b/bin/functions/load-config.py
@@ -443,14 +443,14 @@ def generate_optional_value():  # get some critical values from environment or m
                 # parse yarn resource manager from hadoop conf
                 yarn_site_file = os.path.join(HibenchConf["hibench.hadoop.configure.dir"], "yarn-site.xml")
                 with open(yarn_site_file) as f:
-                    match_address=re.findall("\<property\>\s*\<name\>\s*yarn.resourcemanager.address\s*\<\/name\>\s*\<value\>([a-zA-Z\-\._0-9]+)(:\d+)\<\/value\>", f.read())
-                    #match_hostname=re.findall("\<property\>\s*\<name\>\s*yarn.resourcemanager.hostname\s*\<\/name\>\s*\<value\>([a-zA-Z\-\._0-9]+)(:\d+)\<\/value\>", f.read())
+                    file_content = f.read()
+                    match_address=re.findall("\<property\>\s*\<name\>\s*yarn.resourcemanager.address\s*\<\/name\>\s*\<value\>([a-zA-Z\-\._0-9]+)(:\d+)?\<\/value\>", file_content)
+                    match_hostname=re.findall("\<property\>\s*\<name\>\s*yarn.resourcemanager.hostname\s*\<\/name\>\s*\<value\>([a-zA-Z\-\._0-9]+)(:\d+)?\<\/value\>", file_content)
 		    if match_address:
                         resourcemanager_hostname = match_address[0][0]
                         HibenchConf['hibench.masters.hostnames'] = resourcemanager_hostname
                         HibenchConfRef['hibench.masters.hostnames'] = "Parsed from "+ yarn_site_file
-                    elif re.findall("\<property\>\s*\<name\>\s*yarn.resourcemanager.hostname\s*\<\/name\>\s*\<value\>([a-zA-Z\-\._0-9]+)(:\d+)\<\/value\>", f.read()):
-                        match_hostname=re.findall("\<property\>\s*\<name\>\s*yarn.resourcemanager.hostname\s*\<\/name\>\s*\<value\>([a-zA-Z\-\._0-9]+)(:\d+)\<\/value\>", f.read())
+                    elif match_hostname:
 			resourcemanager_hostname = match_hostname[0][0]
                         HibenchConf['hibench.masters.hostnames'] = resourcemanager_hostname
                         HibenchConfRef['hibench.masters.hostnames'] = "Parsed from "+ yarn_site_file


### PR DESCRIPTION
The content of yarn-site.xml was read multiple times, which means that only yarn.resourcemanager.address would have been found (as the second call to f.read() returns the empty string). This PR introduces a fix for this.

The PR also introduces that port numbers are no longer required (as they are not mandatory in yarn-site.xml either).