### PR TITLE
Fix an argument error in Spark Java Kmeans workload

### DIFF
--- a/workloads/kmeans/spark/java/bin/run.sh
+++ b/workloads/kmeans/spark/java/bin/run.sh
@@ -27,7 +27,7 @@ rmr-hdfs $OUTPUT_HDFS || true
 SIZE=`dir_size $INPUT_HDFS`
 START_TIME=`timestamp`
 
-run-spark-job org.apache.spark.examples.mllib.JavaKMeans $INPUT_HDFS/samples $K -$MAX_ITERATION
+run-spark-job org.apache.spark.examples.mllib.JavaKMeans $INPUT_HDFS/samples $K $MAX_ITERATION
 END_TIME=`timestamp`
 
 gen_report ${START_TIME} ${END_TIME} ${SIZE}


### PR DESCRIPTION
The argument MAX_ITERATION should not be a negative number.