### PR TITLE
Fix SIZE of Join test report

### DIFF
--- a/workloads/join/mapreduce/bin/run.sh
+++ b/workloads/join/mapreduce/bin/run.sh
@@ -43,7 +43,7 @@ END_TIME=`timestamp`
 stop-monitor $MONITOR_PID
 
 sleep 5
-SIZE=`dir_size $OUTPUT_HDFS`
+SIZE=`dir_size $INPUT_HDFS`
 
 gen_report ${START_TIME} ${END_TIME} ${SIZE:-}
 show_bannar finish

--- a/workloads/join/spark/java/bin/run.sh
+++ b/workloads/join/spark/java/bin/run.sh
@@ -27,7 +27,7 @@ HIVEBENCH_SQL_FILE=${WORKLOAD_RESULT_FOLDER}/rankings_uservisits_join.hive
 prepare-sql-join ${HIVEBENCH_SQL_FILE}
 
 START_TIME=`timestamp`
-SIZE=`dir_size $INPUT_HDFS/uservisits`
+SIZE=`dir_size $INPUT_HDFS`
 rmr-hdfs $OUTPUT_HDFS
 run-spark-job com.intel.sparkbench.sql.JavaSparkSQLBench JavaJoin ${HIVEBENCH_SQL_FILE}
 


### PR DESCRIPTION
Hi.

At Join test, there are 3 type of SIZE

1. Python,Scala
 SIZE=`dir_size $INPUT_HDFS`
2. Java
 SIZE=`dir_size $INPUT_HDFS/uservisits`
3. Hadoop
 SIZE=`dir_size $OUTPUT_HDFS`

I was confused that.
So I propose to use "dir_size $INPUT_HDFS" for all Join test.
(I know Aggregation test have same problem)

thanks