### PR TITLE
Fix duplicate keys in terasort output

### DIFF
--- a/src/sparkbench/pom.xml
+++ b/src/sparkbench/pom.xml
@@ -80,6 +80,12 @@
             <groupId>org.apache.mahout</groupId>
             <artifactId>mahout-core</artifactId>
             <version>${mahout.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-core</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.mahout</groupId>

--- a/src/sparkbench/src/multiapi/java/com/intel/sparkbench/MR2/JavaTeraSort.java
+++ b/src/sparkbench/src/multiapi/java/com/intel/sparkbench/MR2/JavaTeraSort.java
@@ -51,7 +51,7 @@ public final class JavaTeraSort {
     JavaPairRDD<byte[], byte[]> words = lines.mapToPair(new PairFunction<Tuple2<Text, Text>, byte[], byte[]>() {
         @Override
         public Tuple2<byte[], byte[]> call(Tuple2<Text, Text> e) throws Exception {
-            return new Tuple2<byte[], byte[]>(e._1().getBytes(), e._2().getBytes());
+            return new Tuple2<byte[], byte[]>(e._1().copyBytes(), e._2().copyBytes());
         }
     });
 

--- a/src/sparkbench/src/multiapi/scala/com/intel/sparkbench/MR2/ScalaTeraSort.scala
+++ b/src/sparkbench/src/multiapi/scala/com/intel/sparkbench/MR2/ScalaTeraSort.scala
@@ -43,7 +43,9 @@ object ScalaTeraSort {
     val io = new IOCommon(sc)
 
     //val file = io.load[String](args(0), Some("Text"))
-    val data = sc.newAPIHadoopFile[Text, Text, TeraInputFormat](args(0)).map{case (k,v)=>(k.getBytes, v.getBytes)}
+    val data = sc.newAPIHadoopFile[Text, Text, TeraInputFormat](args(0)).map {
+      case (k,v) => (k.copyBytes, v.copyBytes)
+    }
     val parallel = sc.getConf.getInt("spark.default.parallelism", sc.defaultParallelism)
     val reducer  = IOCommon.getProperty("hibench.default.shuffle.parallelism")
       .getOrElse((parallel / 2).toString).toInt


### PR DESCRIPTION
Fix duplicate keys in the output of JavaTerasort and ScalaTerasort.
The record reader iterator uses the same array buffer. We need copy the byte array instead of using it directly. Otherwise we end up with duplicate keys. 