### PR TITLE
Get FileSystems with appropriate paths

### DIFF
--- a/src/autogen/src/main/java/HiBench/Utils.java
+++ b/src/autogen/src/main/java/HiBench/Utils.java
@@ -151,7 +151,7 @@ public class Utils {
     
 	private static final void shareMapFile(String symbol, int slots, Path mfile, JobConf job) throws IOException, URISyntaxException {
 		
-		FileSystem fs = FileSystem.get(job);
+		FileSystem fs = FileSystem.get(mfile.toUri(), job);
 		if (fs.exists(mfile) && fs.getFileStatus(mfile).isDir()) {
 
 			DistributedCache.createSymlink(job);

--- a/src/autogen/src/main/java/org/apache/hadoop/fs/dfsioe/TestDFSIOEnh.java
+++ b/src/autogen/src/main/java/org/apache/hadoop/fs/dfsioe/TestDFSIOEnh.java
@@ -571,7 +571,7 @@ public class TestDFSIOEnh extends Configured implements Tool {
         fsConfig.setInt("test.io.file.buffer.size", bufferSize);
         fsConfig.setInt("test.io.sampling.interval",tputSampleInterval);
  
-        FileSystem fs = FileSystem.get(fsConfig);
+        FileSystem fs = FileSystem.get(new Path(TEST_ROOT_DIR).toUri(), fsConfig);
 
         //get the configuration of max number of concurrent maps
         JobConf dummyConf = new JobConf(fsConfig, TestDFSIOEnh.class);

--- a/src/autogen/src/main/java/org/apache/mahout/clustering/kmeans/GenKMeansDataset.java
+++ b/src/autogen/src/main/java/org/apache/mahout/clustering/kmeans/GenKMeansDataset.java
@@ -600,7 +600,7 @@ public class GenKMeansDataset extends Configured implements Tool {
         jobConf.set("mapred.output.compression.type", compressType);
         jobConf.set("mapred.output.compression.codec", compressCodec);
         LOG.info("mapred.output.compression.codec=" + jobConf.get("mapred.output.compression.codec"));
-        FileSystem fs = FileSystem.get(jobConf);
+        FileSystem fs = FileSystem.get(new Path(sampleDir).toUri(), jobConf);
 
         sp.setFileSystem(fs, jobConf);
 

--- a/src/pegasus/src/main/java/pegasus/pagerank/PagerankNaive.java
+++ b/src/pegasus/src/main/java/pegasus/pagerank/PagerankNaive.java
@@ -380,7 +380,7 @@ public class PagerankNaive extends Configured implements Tool
 		if( cur_iteration == 1 )
 			gen_initial_vector(number_nodes, vector_path);
 
-		final FileSystem fs = FileSystem.get(getConf());
+		final FileSystem fs = FileSystem.get(vector_path.toUri(), getConf());
 
 		// Run pagerank until converges. 
 		for (i = cur_iteration; i <= niteration; i++) {
@@ -456,8 +456,9 @@ public class PagerankNaive extends Configured implements Tool
 		System.out.println("");
 		
 		// copy it to curbm_path, and delete temporary local file.
-		final FileSystem fs = FileSystem.get(getConf());
-		fs.copyFromLocalFile( true, new Path("./" + file_name), new Path (vector_path.toString()+ "/" + file_name) );
+		Path destination = new Path(vector_path.toString()+ "/" + file_name);
+		final FileSystem fs = FileSystem.get(destination.toUri(), getConf());
+		fs.copyFromLocalFile( true, new Path("./" + file_name), destination);
 	}
 
 	// read neighborhood number after each iteration.


### PR DESCRIPTION
This PR supplies paths to invocations of `FileSystem#get` so that the correct `FileSystem` is returned for the paths that it will be used for. This is necessary in cases where HiBench is being used to test something besides HDFS.