### PR TITLE
change flink version to 1.0.3 to pass compiling

### DIFF
--- a/src/streambench/flinkbench/pom.xml
+++ b/src/streambench/flinkbench/pom.xml
@@ -34,7 +34,7 @@
     <name>Streaming Benchmark Flink</name>
 
     <properties>
-        <flinkVersion>1.1-SNAPSHOT</flinkVersion>
+        <flinkVersion>1.0.3</flinkVersion>
         <jackson.version>2.4.2</jackson.version>
     </properties>
 


### PR DESCRIPTION
@gallenvara 1.1-SNAPSHOT can not compile on test cluster, I just downgrade to latest stable version 1.0.3. If any concern, let me know.