### PR TITLE
Spark 2.0.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 
 - Current version: 5.0
-- Release date: 2015-10-12
+- Release date: 2015-10-12 (Spark 2.0.0 support added 15th of June 2016)
 - Homepage: https://github.com/intel-hadoop/HiBench
 - To ask a question or report an issue, please use Github Issues
 
@@ -110,7 +110,7 @@ Note:
 
   - Apache release of Hadoop 1.x and Hadoop 2.x
   - CDH4/CDH5 release of MR1 and MR2.
-  - Spark1.2 - 1.6
+  - Spark1.2 - 2.0
   - Storm 0.9.3
   - Samza 0.8.0
 

--- a/bin/build-all.sh
+++ b/bin/build-all.sh
@@ -25,7 +25,7 @@ cd $DIR/src/sparkbench && \
 ( mkdir jars | true )
 
 for mr in MR1 MR2; do
-        for spark_version in 1.2 1.3 1.4 1.5 1.6; do
+        for spark_version in 1.2 1.3 1.4 1.5 1.6 2.0; do
                 cp target/*-jar-with-dependencies.jar jars
                 mvn clean package -D spark$spark_version -D $mr
                 if [ $? -ne 0 ]; then
@@ -39,7 +39,7 @@ rm -rf jars
 
 cd $DIR/src/streambench/sparkbench && \
 ( mkdir jars | true )
-for spark_version in 1.3 1.4 1.5 1.6; do
+for spark_version in 1.3 1.4 1.5 1.6 2.0; do
         cp target/*-jar-with-dependencies.jar jars
         mvn clean package -D spark$spark_version
         if [ $? -ne 0 ]; then

--- a/conf/99-user_defined_properties.conf.template
+++ b/conf/99-user_defined_properties.conf.template
@@ -40,9 +40,9 @@ hibench.spark.master		yarn-client
 # jar. Mostly situation it'll be auto probed. Please override if spark
 # version is not probed correctly. For spark version after 1.6, please
 # set it to spark1.6
-# Note, supported values: `spark1.2` to `spark1.6`
+# Note, supported values: `spark1.2` to `spark2.0`
 
-#hibench.spark.version          spark1.6
+#hibench.spark.version          spark2.0
 
 #======================================================
 # Optional settings

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -148,7 +148,7 @@
                 <property><name>!spark1.2</name></property>
             </activation>
 	    <modules>
-	     <!-- <module>streambench</module>-->
+	      <module>streambench</module>
 	    </modules>
 
         </profile>
@@ -163,7 +163,7 @@
                 <property><name>spark1.4</name></property>
             </activation>
 	    <modules>
-	      <!--<module>streambench</module>-->
+	      <module>streambench</module>
 	    </modules>
 
         </profile>
@@ -178,7 +178,7 @@
                 <property><name>spark1.5</name></property>
             </activation>
 	    <modules>
-	      <!--<module>streambench</module>-->
+	      <module>streambench</module>
 	    </modules>
 
         </profile>
@@ -193,11 +193,10 @@
                 <property><name>spark1.6</name></property>
             </activation>
 	    <modules>
-	      <!--<module>streambench</module>-->
+	      <module>streambench</module>
 	    </modules>
 
         </profile>
-
         <profile>
             <id>spark2.0</id>
             <properties>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -202,7 +202,7 @@
             <id>spark2.0</id>
             <properties>
                 <env>spark2.0</env>
-                <spark.version>2.0.0-preview</spark.version>
+                <spark.version>2.0.0</spark.version>
                 <spark.bin.version>2.0</spark.bin.version>
             </properties>
             <activation>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -10,11 +10,11 @@
     <url>http://maven.apache.org</url>
 
     <properties>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <encoding>UTF-8</encoding>
-        <scala.version>2.10.4</scala.version>
-        <scala.binary.version>2.10</scala.binary.version>
+        <scala.version>2.11.8</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
 	<slf4j.version>1.7.5</slf4j.version>
 	<log4j.version>1.2.17</log4j.version>
 	<scopt.version>3.2.0</scopt.version>
@@ -59,19 +59,7 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
-        <repository>
-            <id>scala-tools.org</id>
-            <name>Scala-tools Maven 2 Repository</name>
-            <url>https://oss.sonatype.org/content/groups/scala-tools/</url>
-        </repository>
     </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>scala-tools.org</id>
-            <name>Scala-tools Maven2 Repository</name>
-            <url>https://oss.sonatype.org/content/groups/scala-tools/</url>
-        </pluginRepository>
-    </pluginRepositories>
 
     <build>
         <pluginManagement>
@@ -160,7 +148,7 @@
                 <property><name>!spark1.2</name></property>
             </activation>
 	    <modules>
-	      <module>streambench</module>
+	     <!-- <module>streambench</module>-->
 	    </modules>
 
         </profile>
@@ -175,7 +163,7 @@
                 <property><name>spark1.4</name></property>
             </activation>
 	    <modules>
-	      <module>streambench</module>
+	      <!--<module>streambench</module>-->
 	    </modules>
 
         </profile>
@@ -190,7 +178,7 @@
                 <property><name>spark1.5</name></property>
             </activation>
 	    <modules>
-	      <module>streambench</module>
+	      <!--<module>streambench</module>-->
 	    </modules>
 
         </profile>
@@ -205,9 +193,26 @@
                 <property><name>spark1.6</name></property>
             </activation>
 	    <modules>
-	      <module>streambench</module>
+	      <!--<module>streambench</module>-->
 	    </modules>
 
         </profile>
+
+        <profile>
+            <id>spark2.0</id>
+            <properties>
+                <env>spark2.0</env>
+                <spark.version>2.0.0-preview</spark.version>
+                <spark.bin.version>2.0</spark.bin.version>
+            </properties>
+            <activation>
+                <property><name>spark2.0</name></property>
+            </activation>
+            <modules>
+              <module>streambench</module>
+            </modules>
+
+        </profile>
+
     </profiles>
 </project>

--- a/src/sparkbench/src/main/java/com/intel/sparkbench/JavaBayes.java
+++ b/src/sparkbench/src/main/java/com/intel/sparkbench/JavaBayes.java
@@ -43,6 +43,7 @@ import java.lang.Long;
 import java.util.*;
 import java.util.regex.Pattern;
 
+
 /*
  * Adopted from spark's doc: http://spark.apache.org/docs/latest/mllib-naive-bayes.html
  */

--- a/src/sparkbench/src/main/java/com/intel/sparkbench/JavaBayes.java
+++ b/src/sparkbench/src/main/java/com/intel/sparkbench/JavaBayes.java
@@ -43,7 +43,6 @@ import java.lang.Long;
 import java.util.*;
 import java.util.regex.Pattern;
 
-
 /*
  * Adopted from spark's doc: http://spark.apache.org/docs/latest/mllib-naive-bayes.html
  */
@@ -75,8 +74,8 @@ public final class JavaBayes {
     JavaPairRDD<String, Long> wordCount = data
             .flatMap(new FlatMapFunction<Tuple2<String, String>, String>() {
                 @Override
-                public Iterable<String> call(Tuple2<String, String> e) {
-                    return Arrays.asList(SPACE.split(e._2()));
+                public Iterator<String> call(Tuple2<String, String> e) {
+                    return Arrays.asList(SPACE.split(e._2())).iterator();
                 }
             })
             .mapToPair(new PairFunction<String, String, Long>() {

--- a/src/sparkbench/src/main/java/org/apache/spark/examples/JavaPageRank.java
+++ b/src/sparkbench/src/main/java/org/apache/spark/examples/JavaPageRank.java
@@ -26,8 +26,6 @@ package org.apache.spark.examples;
 import com.intel.sparkbench.IOCommon;
 import scala.Tuple2;
 
-import com.google.common.collect.Iterables;
-
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
@@ -40,6 +38,8 @@ import org.apache.spark.api.java.function.PairFunction;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.Iterator;
+import com.google.common.collect.Iterables;
 
 /**
  * Computes the PageRank of URLs from an input file. Input file should
@@ -81,7 +81,7 @@ public final class JavaPageRank {
       @Override
       public Tuple2<String, String> call(String s) {
         String[] parts = SPACES.split(s);
-        // Modified by Lv: accept last two vaules from HiBench generated PageRank data format
+        // Modified by Lv: accept last two values from HiBench generated PageRank data format
         return new Tuple2<String, String>(parts[parts.length-2], parts[parts.length-1]);
       }
     }).distinct().groupByKey().cache();
@@ -100,13 +100,13 @@ public final class JavaPageRank {
       JavaPairRDD<String, Double> contribs = links.join(ranks).values()
         .flatMapToPair(new PairFlatMapFunction<Tuple2<Iterable<String>, Double>, String, Double>() {
           @Override
-          public Iterable<Tuple2<String, Double>> call(Tuple2<Iterable<String>, Double> s) {
+          public Iterator<Tuple2<String, Double>> call(Tuple2<Iterable<String>, Double> s) {
             int urlCount = Iterables.size(s._1);
             List<Tuple2<String, Double>> results = new ArrayList<Tuple2<String, Double>>();
             for (String n : s._1) {
               results.add(new Tuple2<String, Double>(n, s._2() / urlCount));
             }
-            return results;
+            return results.iterator();
           }
       });
 

--- a/src/sparkbench/src/main/java/org/apache/spark/examples/JavaWordCount.java
+++ b/src/sparkbench/src/main/java/org/apache/spark/examples/JavaWordCount.java
@@ -35,6 +35,7 @@ import org.apache.spark.api.java.function.PairFunction;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.Iterator;
 
 public final class JavaWordCount {
   private static final Pattern SPACE = Pattern.compile(" ");
@@ -52,8 +53,8 @@ public final class JavaWordCount {
 
     JavaRDD<String> words = lines.flatMap(new FlatMapFunction<String, String>() {
       @Override
-      public Iterable<String> call(String s) {
-        return Arrays.asList(SPACE.split(s));
+      public Iterator<String> call(String s) {
+        return Arrays.asList(SPACE.split(s)).iterator();
       }
     });
 

--- a/src/sparkbench/src/main/scala/com/intel/sparkbench/ScalaSparkSQLBench.scala
+++ b/src/sparkbench/src/main/scala/com/intel/sparkbench/ScalaSparkSQLBench.scala
@@ -18,7 +18,7 @@
 package com.intel.sparkbench.sql
 
 import org.apache.spark.{SparkConf, SparkContext}
-import org.apache.spark.sql.hive.HiveContext
+import org.apache.spark.sql.SQLContext
 
 /*
  * ported from HiBench's hive bench
@@ -27,7 +27,7 @@ object ScalaSparkSQLBench{
   def main(args: Array[String]){
     if (args.length < 2){
       System.err.println(
-        s"Usage: $ScalaSparkSQLBench <workload name> <SQL sciprt file>"
+        s"Usage: $ScalaSparkSQLBench <workload name> <SQL script file>"
       )
       System.exit(1)
     }
@@ -35,7 +35,7 @@ object ScalaSparkSQLBench{
     val sql_file = args(1)
     val sparkConf = new SparkConf().setAppName(workload_name)
     val sc = new SparkContext(sparkConf)
-    val hc = new HiveContext(sc)
+    val hc = new SQLContext(sc)
 
     val _sql = scala.io.Source.fromFile(sql_file).mkString
     _sql.split(';').foreach { x =>

--- a/src/sparkbench/src/main/scala/com/intel/sparkbench/nweight/Driver.scala
+++ b/src/sparkbench/src/main/scala/com/intel/sparkbench/nweight/Driver.scala
@@ -4,7 +4,7 @@ import org.apache.spark.{SparkContext, SparkConf}
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
-import org.apache.spark.scheduler.{JobLogger, StatsReportListener}
+import org.apache.spark.scheduler.StatsReportListener
 
 import com.esotericsoftware.kryo.{Kryo, Serializer => KSerializer}
 import com.esotericsoftware.kryo.io.{Input => KryoInput, Output => KryoOutput}
@@ -64,7 +64,6 @@ object NWeight extends Serializable{
       sparkConf.setAppName("NWeightPregel")
     val sc = new SparkContext(sparkConf)
  
-    sc.addSparkListener(new JobLogger)
     sc.addSparkListener(new StatsReportListener)
 
     if (model.toLowerCase == "graphx") {

--- a/src/sparkbench/src/main/scala/com/intel/sparkbench/nweight/GraphxNWeight.scala
+++ b/src/sparkbench/src/main/scala/com/intel/sparkbench/nweight/GraphxNWeight.scala
@@ -19,25 +19,27 @@ import it.unimi.dsi.fastutil.longs.Long2DoubleOpenHashMap
 
 object GraphxNWeight extends Serializable{
 
-  def mapF(edge: EdgeTriplet[SizedPriorityQueue, Double]) = {
-    val m = new Long2DoubleOpenHashMap()
-    val w1 = edge.attr
+  /* This needs to return an EdgeContext for aggregateMessages */
+  def mapFunction(edge: EdgeContext[SizedPriorityQueue, Double, Long2DoubleOpenHashMap]) = {
+    /* This code produces an edge triple */
+    val theMap = new Long2DoubleOpenHashMap()
+    val edgeAttribute = edge.attr
     val id = edge.srcId
     edge.dstAttr.foreach{ case (target, wn) =>
       if (target != id)
-        m.put(target, wn*w1)
+        theMap.put(target, wn * edgeAttribute)
     }
-    Iterator((id, m))
+    Iterator((id, theMap))
   }
 
-  def reduceF(c1: Long2DoubleOpenHashMap, c2: Long2DoubleOpenHashMap) = {
+  def reduceFunction(c1: Long2DoubleOpenHashMap, c2: Long2DoubleOpenHashMap) = {
     c2.long2DoubleEntrySet()
       .fastIterator()
       .foreach(pair => c1.put(pair.getLongKey(), c1.get(pair.getLongKey()) + pair.getDoubleValue()))
     c1
   }
 
-  def updateF (id: VertexId, vdata: SizedPriorityQueue, msg: Option[Long2DoubleOpenHashMap]) = {
+  def updateFunction(id: VertexId, vdata: SizedPriorityQueue, msg: Option[Long2DoubleOpenHashMap]) = {
     vdata.clear()
     val weightMap = msg.orNull
     if (weightMap != null) {
@@ -78,8 +80,10 @@ object GraphxNWeight extends Serializable{
 
     var msg: RDD[(VertexId, Long2DoubleOpenHashMap)] = null
     for (i <- 2 to step) {
-      msg = g.mapReduceTriplets(mapF _, reduceF _, Some(g.vertices , EdgeDirection.In))
-      g = g.outerJoinVertices(msg)(updateF _).persist(storageLevel)
+
+//      msg = g.mapReduceTriplets(mapFunction _, reduceFunction _, Some(g.vertices , EdgeDirection.In))
+      msg = g.aggregateMessages(mapFunction _, reduceFunction _, TripletFields.Src)
+      g = g.outerJoinVertices(msg)(updateFunction _).persist(storageLevel)
     }
 
     g.vertices.map { case (vid, vdata) => 

--- a/src/sparkbench/src/main/scala/org/apache/spark/BaseRangePartitioner.scala
+++ b/src/sparkbench/src/main/scala/org/apache/spark/BaseRangePartitioner.scala
@@ -33,8 +33,8 @@ import scala.util.hashing._
  */
 
 class BaseRangePartitioner [K : Ordering : ClassTag, V]
-      (@transient partitions: Int,
-       @transient rdd: RDD[_ <: Product2[K,V]],
+      (@transient private val partitions: Int,
+       @transient private val rdd: RDD[_ <: Product2[K,V]],
        private var ascending: Boolean = true)
   extends Partitioner {   // Adopted from scala's RangePartitioner
   

--- a/src/sparkbench/src/main/scala/org/apache/spark/ConfigurableOrderedRDDFunctions.scala
+++ b/src/sparkbench/src/main/scala/org/apache/spark/ConfigurableOrderedRDDFunctions.scala
@@ -31,7 +31,7 @@ import scala.reflect.ClassTag
 
 class ConfigurableOrderedRDDFunctions[K : Ordering : ClassTag, V: ClassTag,
                                       P <: Product2[K, V] : ClassTag]
-      (self: RDD[P]) extends Logging with Serializable {
+      (self: RDD[P]) extends org.apache.spark.internal.Logging with Serializable {
   private val ordering = implicitly[Ordering[K]]
 
   def sortByKeyWithPartitioner(partitioner: Partitioner,

--- a/src/sparkbench/src/multiapi/scala/com/intel/sparkbench/MR2/ScalaTeraSort.scala
+++ b/src/sparkbench/src/multiapi/scala/com/intel/sparkbench/MR2/ScalaTeraSort.scala
@@ -24,13 +24,16 @@ import org.apache.spark._
 import org.apache.spark.rdd._
 import org.apache.spark.SparkContext._
 
+import Ordering.Implicits._
+
 import scala.reflect.ClassTag
 
 object ScalaTeraSort {
   implicit def rddToSampledOrderedRDDFunctions[K: Ordering : ClassTag, V: ClassTag]
   (rdd: RDD[(K, V)]) = new ConfigurableOrderedRDDFunctions[K, V, (K, V)](rdd)
 
-  implicit def ArrayByteOrdering: Ordering[Array[Byte]] = Ordering.fromLessThan{case (a, b)=> a.compareTo(b)<0}
+  implicit def ArrayByteOrdering: Ordering[Array[Byte]] = Ordering.fromLessThan{_ > _}
+
   def main(args: Array[String]) {
     if (args.length != 2) {
       System.err.println(

--- a/src/sparkbench/src/multiapi/scala/com/intel/sparkbench/MR2/ScalaTeraSort.scala
+++ b/src/sparkbench/src/multiapi/scala/com/intel/sparkbench/MR2/ScalaTeraSort.scala
@@ -23,7 +23,7 @@ import org.apache.hadoop.io.Text
 import org.apache.spark._
 import org.apache.spark.rdd._
 import org.apache.spark.SparkContext._
-
+import org.apache.hadoop.io.BytesWritable
 import Ordering.Implicits._
 
 import scala.reflect.ClassTag
@@ -32,7 +32,8 @@ object ScalaTeraSort {
   implicit def rddToSampledOrderedRDDFunctions[K: Ordering : ClassTag, V: ClassTag]
   (rdd: RDD[(K, V)]) = new ConfigurableOrderedRDDFunctions[K, V, (K, V)](rdd)
 
-  implicit def ArrayByteOrdering: Ordering[Array[Byte]] = Ordering.fromLessThan{_ > _}
+  implicit def ArrayByteOrdering: Ordering[Array[Byte]] = Ordering.fromLessThan{case (a, b)=> (new BytesWritable(a)).compareTo((new 
+    BytesWritable(b)))<0} 
 
   def main(args: Array[String]) {
     if (args.length != 2) {

--- a/src/streambench/datagen/pom.xml
+++ b/src/streambench/datagen/pom.xml
@@ -16,10 +16,9 @@
  <dependencies>
    <dependency>
      <groupId>org.apache.kafka</groupId>
-     <artifactId>kafka-clients</artifactId>
-     <version>0.8.1</version>
-     <scope>system</scope>
-     <systemPath>${basedir}/lib/kafka-clients-0.8.1.jar</systemPath>
+     <!--<artifactId>kafka-clients</artifactId>-->
+     <artifactId>kafka_2.11</artifactId>
+     <version>0.8.2.2</version>
    </dependency>
     <dependency>
         <groupId>org.apache.hadoop</groupId>

--- a/src/streambench/datagen/src/main/java/com/intel/hibench/streambench/NewKafkaConnector.java
+++ b/src/streambench/datagen/src/main/java/com/intel/hibench/streambench/NewKafkaConnector.java
@@ -39,10 +39,10 @@ public class NewKafkaConnector {
 
   public NewKafkaConnector(String brokerList, ConfigLoader cl) {
     Properties props = new Properties();
-    props.setProperty(ProducerConfig.REQUIRED_ACKS_CONFIG, "1");
-    props.setProperty(ProducerConfig.BROKER_LIST_CONFIG, brokerList);
-    props.setProperty(ProducerConfig.METADATA_FETCH_TIMEOUT_CONFIG, Integer.toString(5 * 1000));
-    props.setProperty(ProducerConfig.REQUEST_TIMEOUT_CONFIG, Integer.toString(Integer.MAX_VALUE));
+    props.put("request.required.acks", "1");
+    props.put("metadata.broker.list", brokerList);
+    props.put("metadata.fetch.timeout.ms", Integer.toString(5 * 1000));
+    props.put("request.timeout.ms", Integer.toString(Integer.MAX_VALUE));
     producer = new KafkaProducer(props);
     Data1Length = Integer.parseInt(cl.getProperty("hibench.streamingbench.datagen.data1.length"));
   }

--- a/src/streambench/pom.xml
+++ b/src/streambench/pom.xml
@@ -16,9 +16,22 @@
 
     <repositories>
       <repository>
+        <id>central</id>
+         <name>Maven Repository</name>
+         <url>https://repo1.maven.org/maven2</url>
+         <releases>
+           <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+      </repository>
+     <!--
+      <repository>
 	<id>github-releases</id>
 	<url>http://oss.sonatype.org/content/repositories/github-releases/</url>
       </repository>
+      -->
       <repository>
 	<id>clojars.org</id>
 	<url>http://clojars.org/repo</url>

--- a/src/streambench/samzabench/pom.xml
+++ b/src/streambench/samzabench/pom.xml
@@ -105,6 +105,17 @@
   </dependencies>
 
   <repositories>
+   <repository>
+     <id>central</id>
+       <name>Maven Repository</name>
+       <url>https://repo1.maven.org/maven2</url>
+       <releases>
+         <enabled>true</enabled>
+        </releases>
+        <snapshots>
+          <enabled>false</enabled>
+        </snapshots>
+      </repository>
     <repository>
       <id>my-local-repo</id>
       <url>file://${user.home}/.m2/repository</url>
@@ -112,11 +123,6 @@
     <repository>
       <id>apache-releases</id>
       <url>https://repository.apache.org/content/groups/public</url>
-    </repository>
-    <repository>
-      <id>scala-tools.org</id>
-      <name>Scala-tools Maven2 Repository</name>
-      <url>https://oss.sonatype.org/content/groups/scala-tools</url>
     </repository>
   </repositories>
 

--- a/src/streambench/sparkbench/pom.xml
+++ b/src/streambench/sparkbench/pom.xml
@@ -50,41 +50,33 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-bagel_${scala.binary.version}</artifactId>
-      <version>${spark.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
       <artifactId>spark-graphx_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming-twitter_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming-kafka-0-8-assembly_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming-kafka_${scala.binary.version}</artifactId>
-      <version>${spark.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-streaming-flume_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
     </dependency>
+   <!--
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-streaming-zeromq_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
     </dependency>
+  
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-streaming-mqtt_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
-    </dependency>
+   -->
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase</artifactId>
@@ -102,18 +94,13 @@
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka_2.10</artifactId>
-      <version>0.8.1</version>
+      <artifactId>kafka_2.11</artifactId>
+      <version>0.8.2.2</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
       <version>${jetty.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.twitter</groupId>
-      <artifactId>algebird-core_${scala.binary.version}</artifactId>
-      <version>0.1.11</version>
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>

--- a/src/streambench/sparkbench/src/main/scala/com/intel/hibench/streambench/spark/util/LogUtil.scala
+++ b/src/streambench/sparkbench/src/main/scala/com/intel/hibench/streambench/spark/util/LogUtil.scala
@@ -17,15 +17,14 @@
 
 package com.intel.hibench.streambench.spark.util
 
-import org.apache.spark.Logging
 import org.apache.log4j.{Level, Logger}
 import com.intel.hibench.streambench.spark.RunBench
 
-object BenchLogUtil extends Logging{
+object BenchLogUtil {
   def setLogLevel(){
     val log4jInitialized = Logger.getRootLogger.getAllAppenders.hasMoreElements
 	if (!log4jInitialized) {
-	  logInfo("Setting log level to [WARN] for streaming example." +
+	  println("Setting log level to [WARN] for streaming example." +
         " To override add a custom log4j.properties to the classpath.")
       Logger.getRootLogger.setLevel(Level.WARN)
 	}

--- a/src/streambench/sparkbench/src/multiapi/scala/spark2.0/LatencyCollector.scala
+++ b/src/streambench/sparkbench/src/multiapi/scala/spark2.0/LatencyCollector.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.hibench.streambench.spark.metrics
+
+import com.intel.hibench.streambench.spark.entity.ParamEntity
+import org.apache.spark.streaming.StreamingContext
+import org.apache.spark.streaming.scheduler._
+import com.intel.hibench.streambench.spark.util._
+
+class StopContextThread(ssc: StreamingContext) extends Runnable {
+  def run {
+    ssc.stop(true, true)
+  }
+}
+
+class LatencyListener(ssc: StreamingContext, params: ParamEntity) extends StreamingListener {
+
+  var startTime=0L
+  var endTime=0L
+  //This delay is processDelay of every batch * record count in this batch
+  var totalDelay=0L
+  var hasStarted=false
+  var batchCount=0
+  var totalRecords=0L
+
+  val thread: Thread = new Thread(new StopContextThread(ssc))
+
+  override def onBatchCompleted(batchCompleted: StreamingListenerBatchCompleted): Unit={
+    val batchInfo = batchCompleted.batchInfo
+    val prevCount=totalRecords
+    var recordThisBatch = batchInfo.numRecords
+
+    if (!thread.isAlive) {
+      totalRecords += recordThisBatch
+      BenchLogUtil.logMsg("LatencyController:    this batch: " + recordThisBatch)
+      BenchLogUtil.logMsg("LatencyController: total records: " + totalRecords)
+    }
+
+    if (totalRecords >= params.recordCount) {
+      if (hasStarted && !thread.isAlive) {
+        //not receiving any data more, finish
+        endTime = System.currentTimeMillis()
+        val totalTime = (endTime-startTime).toDouble/1000
+        //This is weighted avg of every batch process time. The weight is records processed int the batch
+        val avgLatency = totalDelay.toDouble/totalRecords
+        if (avgLatency > params.batchInterval.toDouble*1000)
+          BenchLogUtil.logMsg("WARNING:SPARK CLUSTER IN UNSTABLE STATE. TRY REDUCE INPUT SPEED")
+
+        val avgLatencyAdjust = avgLatency + params.batchInterval.toDouble*500
+        val recordThroughput = params.recordCount / totalTime
+        BenchLogUtil.logMsg("Batch count = " + batchCount)
+        BenchLogUtil.logMsg("Total processing delay = " + totalDelay + " ms")
+        BenchLogUtil.logMsg("Consumed time = " + totalTime + " s")
+        BenchLogUtil.logMsg("Avg latency/batchInterval = " + avgLatencyAdjust + " ms")
+        BenchLogUtil.logMsg("Avg records/sec = " + recordThroughput + " records/s")
+        thread.start
+      }
+    } else if (!hasStarted) {
+      startTime = batchCompleted.batchInfo.submissionTime
+      hasStarted = true
+    }
+
+    if (hasStarted) {
+//      BenchLogUtil.logMsg("This delay:"+batchCompleted.batchInfo.processingDelay+"ms")
+      batchCompleted.batchInfo.processingDelay match {
+        case Some(value) => totalDelay += value*recordThisBatch
+        case None =>  //Nothing
+      }
+      batchCount = batchCount+1
+    }
+  }
+  
+}

--- a/src/streambench/stormbench/pom.xml
+++ b/src/streambench/stormbench/pom.xml
@@ -64,8 +64,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka_2.10</artifactId>
-      <version>0.8.1.1</version>
+      <artifactId>kafka_2.11</artifactId>
+      <version>0.8.2.2</version>
       <scope>compile</scope>
       <exclusions>
 	<exclusion>


### PR DESCRIPTION
In this PR I've changed a few methods so that we can compile and run successfully with Spark 2.0, I've created this pull request so everyone can see the changes I have made and we can work together to get this contributed

Here are the known problems we should resolve
1) Streambench - lots of changes and I need to figure out which are neccessary, I didn't want to touch this at all
2) I build with mvn -T 1C package -D spark2.0 from the sparkbench directory containing the pom.xml, run-all.sh no longer works correctly
3) presumably we want a new HiBench release: 6 instead of 5 snapshot (I think moving up a Spark major version is definitely sufficient of a new HIBench release)
4) we think there's a performance problem in at least one place (ordering in ScalaTeraSort) so that line of code is likely to change, I'm also concerned about my other changes so looking for a code review, currently we consistently see Spark 2.0 with this benchmark performing slower than Spark 1.x
5) conf/99-user_defined_properties.conf.template has the Spark version now being 2.0 instead of 1.6
6) I have kafka provided and a newer version is specified, do we want this?
7) we were previously looking in the sonatype repository for jars no longer present and so I added the mvn central repository lookup

Also, do we want to create a new branch? 

How should we handle the multiple Scala versions (you'll see here I set the scala version to be 2.11.8 but presumably we'd still want 2.10.5 for 1.x)
