### PR TITLE
Fixes an issue where DFSioe ignores the value of test.build.data 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ target/
 derby.log
 metastore_db/
 report/
+.classpath
+.project
+.settings/

--- a/src/autogen/src/main/java/org/apache/hadoop/fs/dfsioe/Analyzer.java
+++ b/src/autogen/src/main/java/org/apache/hadoop/fs/dfsioe/Analyzer.java
@@ -107,7 +107,7 @@ public class Analyzer {
 	    job.setReducerClass(_Reducer.class);
 	    job.setOutputKeyClass(Text.class);
 	    job.setOutputValueClass(Text.class);
-	    FileInputFormat.addInputPath(job, new Path(TestDFSIOEnh.READ_DIR, "part-00000"));
+	    FileInputFormat.addInputPath(job, new Path(DfsioeConfig.getInstance().getReadDir(conf), "part-00000"));
 	    FileOutputFormat.setOutputPath(job, outdir);
 	    System.exit(job.waitForCompletion(true) ? 0 : 1);
 	}

--- a/src/autogen/src/main/java/org/apache/hadoop/fs/dfsioe/DfsioeConfig.java
+++ b/src/autogen/src/main/java/org/apache/hadoop/fs/dfsioe/DfsioeConfig.java
@@ -1,0 +1,142 @@
+package org.apache.hadoop.fs.dfsioe;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+public final class DfsioeConfig {
+	private static DfsioeConfig instance = null;
+
+	private DfsioeConfig() {
+	}
+
+	public static synchronized DfsioeConfig getInstance() {
+		if (instance == null)
+			instance = new DfsioeConfig();
+		return instance;
+	}
+
+	private static final Log LOG = LogFactory.getLog(DfsioeConfig.class);
+
+	private String testRootDir;
+	private Path controlDir;
+	private Path writeDir;
+	private Path readDir;
+	private Path dataDir;
+	private Path reportDir;
+	private Path reportTmp;
+
+	public String getTestRootDir() {
+		if (testRootDir == null) {
+			throw new RuntimeException(
+					"testRootDir should not be null at this point");
+		}
+		return testRootDir;
+	}
+
+	public String getTestRootDir(Configuration conf) {
+		String propName = "test.build.data";
+		if (testRootDir == null) {
+			testRootDir = System.getProperty(propName);
+			if( testRootDir != null ) {
+				LOG.info("Found '" + propName + "' in System properties, value is '" + testRootDir + "'");
+			} else {
+				testRootDir = safeGet(conf, propName);
+				LOG.info("Found '" + propName + "' in Hadoop configuration, value is '" + testRootDir + "'");
+			}
+			LOG.info("Setting testRootDir to '" + testRootDir + "'");
+		}
+
+		return testRootDir;
+	}
+
+	public Path getControlDir() {
+		if (controlDir == null) {
+			controlDir = new Path(getTestRootDir(), "io_control");
+		}
+		return controlDir;
+	}
+
+	public Path getControlDir(Configuration conf) {
+		controlDir = new Path(getTestRootDir(conf), "io_control");
+
+		return controlDir;
+	}
+
+	public Path getWriteDir() {
+		if (writeDir == null) {
+			writeDir = new Path(getTestRootDir(), "io_write");
+		}
+		return writeDir;
+	}
+
+	public Path getWriteDir(Configuration conf) {
+		writeDir = new Path(getTestRootDir(conf), "io_write");
+
+		return writeDir;
+	}
+
+	public Path getReadDir() {
+		if (readDir == null) {
+			readDir = new Path(getTestRootDir(), "io_read");
+		}
+		return readDir;
+	}
+
+	public Path getReadDir(Configuration conf) {
+		readDir = new Path(getTestRootDir(conf), "io_read");
+
+		return readDir;
+	}
+
+	public Path getDataDir() {
+		if (dataDir == null) {
+			dataDir = new Path(getTestRootDir(), "io_data");
+		}
+		return dataDir;
+	}
+
+	public Path getDataDir(Configuration conf) {
+		dataDir = new Path(getTestRootDir(conf), "io_data");
+
+		return dataDir;
+	}
+
+	public Path getReportDir() {
+		if (reportDir == null) {
+			reportDir = new Path(getTestRootDir(), "reports");
+		}
+		return reportDir;
+	}
+
+	public Path getReportDir(Configuration conf) {
+		reportDir = new Path(getTestRootDir(conf), "reports");
+
+		return reportDir;
+	}
+
+	public Path getReportTmp() {
+		if (reportTmp == null) {
+			reportTmp = new Path(getTestRootDir(), "_merged_reports.txt");
+		}
+		return reportTmp;
+	}
+
+	public Path getReportTmp(Configuration conf) {
+		reportTmp = new Path(getTestRootDir(conf), "_merged_reports.txt");
+
+		return reportTmp;
+	}
+
+	public String safeGet(Configuration conf, String prop) {
+		if (conf == null) {
+			throw new RuntimeException("null config not allowed");
+		}
+		if (conf.get(prop) == null) {
+			throw new RuntimeException("Property " + prop + " cannot be empty");
+		}
+		return conf.get(prop);
+	}
+
+}


### PR DESCRIPTION
This PR address issue #275 

For some reason the test.build.data property is not accessible in the prepare step for dfsioe, but is accessible in the hadoop job configuration.  This PR address the issue by adding a singleton class that controls access to the config variables and employs a search pattern in System properties first then hadoop config next and throws RTE if neither are set.   Using this class helped me determine where the property was set, and which method to access the config by (sometimes getConf, sometimes fsConfig).

The following log messages from this code demonstrate the problem.
```
$ find . -name '*.log' | xargs grep -A2 -B1 'Setting testRootDir' 
./report/dfsioe/prepare/bench.log-16/08/19 11:14:45 INFO dfsioe.DfsioeConfig: Found 'test.build.data' in Hadoop configuration, value is 'hdfs://192.168.0.1:8020/user/builder/HiBench/Dfsioe/Input'
./report/dfsioe/prepare/bench.log:16/08/19 11:14:45 INFO dfsioe.DfsioeConfig: Setting testRootDir to 'hdfs://192.168.0.1:8020/user/builder/HiBench/Dfsioe/Input'
./report/dfsioe/prepare/bench.log-16/08/19 11:14:46 INFO dfsioe.TestDFSIOEnh: created control files for: 16 files
./report/dfsioe/prepare/bench.log-16/08/19 11:14:46 INFO client.RMProxy: Connecting to ResourceManager at /192.168.0.33:8050
--
./report/dfsioe/mapreduce/bench.log-16/08/19 11:15:19 INFO dfsioe.DfsioeConfig: Found 'test.build.data' in System properties, value is 'hdfs://192.168.0.1:8020/user/builder/HiBench/Dfsioe/Input'
./report/dfsioe/mapreduce/bench.log:16/08/19 11:15:19 INFO dfsioe.DfsioeConfig: Setting testRootDir to 'hdfs://192.168.0.1:8020/user/builder/HiBench/Dfsioe/Input'
./report/dfsioe/mapreduce/bench.log-16/08/19 11:15:19 INFO dfsioe.TestDFSIOEnh: created control files for: 16 files
./report/dfsioe/mapreduce/bench.log-16/08/19 11:15:19 INFO client.RMProxy: Connecting to ResourceManager at /192.168.0.33:8050
--
./report/dfsioe/mapreduce/bench.log-16/08/19 11:16:04 INFO dfsioe.DfsioeConfig: Found 'test.build.data' in System properties, value is 'hdfs://192.168.0.1:8020/user/builder/HiBench/Dfsioe/Input'
./report/dfsioe/mapreduce/bench.log:16/08/19 11:16:04 INFO dfsioe.DfsioeConfig: Setting testRootDir to 'hdfs://192.168.0.1:8020/user/builder/HiBench/Dfsioe/Input'
./report/dfsioe/mapreduce/bench.log-16/08/19 11:16:05 INFO dfsioe.TestDFSIOEnh: created control files for: 16 files
./report/dfsioe/mapreduce/bench.log-16/08/19 11:16:05 INFO client.RMProxy: Connecting to ResourceManager at /192.168.0.33:8050
```
