### PR TITLE
Add support for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: java
+jdk:
+  - oraclejdk8
+  - openjdk7
+install: cd src && mvn install -q -DskipTests=true -Dmaven.javadoc.skip=true
+script: mvn test -q


### PR DESCRIPTION
Now travis only support for `Oracle JDK 7`, `Oracle JDK 8`, `OpenJDK 6`, `OpenJDK 7`, so here `OpenJDK` is set to `OpenJDK 7` . 
Also, because the limit of travis log, here only log the `error message`.