### PR TITLE
Spark2.0 support to HiBench 6.0

### DIFF
--- a/autogen/src/main/java/HiBench/HiveData.java
+++ b/autogen/src/main/java/HiBench/HiveData.java
@@ -331,11 +331,11 @@ public class HiveData {
 		job.setInputFormat(NLineInputFormat.class);
 		FileInputFormat.setInputPaths(job, dummy.getPath());
 
-		job.set("mapred.map.output.compression.type", "BLOCK");
-	 	job.set("mapreduce.output.fileoutputformat.compress.type","BLOCK");	
-		MapFileOutputFormat.setCompressOutput(job, true);
+		// job.set("mapred.map.output.compression.type", "BLOCK");
+	 	// job.set("mapreduce.output.fileoutputformat.compress.type","BLOCK");
+		// MapFileOutputFormat.setCompressOutput(job, true);
 //		MapFileOutputFormat.setOutputCompressorClass(job, org.apache.hadoop.io.compress.LzoCodec.class);
-		MapFileOutputFormat.setOutputCompressorClass(job, org.apache.hadoop.io.compress.DefaultCodec.class);
+		// MapFileOutputFormat.setOutputCompressorClass(job, org.apache.hadoop.io.compress.DefaultCodec.class);
 
 		if (options.isSequenceOut()) {
 			job.setOutputFormat(SequenceFileOutputFormat.class);

--- a/bin/functions/workload-functions.sh
+++ b/bin/functions/workload-functions.sh
@@ -389,8 +389,8 @@ set ${MAP_CONFIG_NAME}=$NUM_MAPS;
 set ${REDUCER_CONFIG_NAME}=$NUM_REDS;
 set hive.stats.autogather=false;
 
-CREATE EXTERNAL TABLE uservisits (sourceIP STRING,destURL STRING,visitDate STRING,adRevenue DOUBLE,userAgent STRING,countryCode STRING,languageCode STRING,searchWord STRING,duration INT ) ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS SEQUENCEFILE LOCATION '$INPUT_HDFS/uservisits';
-CREATE EXTERNAL TABLE uservisits_aggre ( sourceIP STRING, sumAdRevenue DOUBLE) STORED AS SEQUENCEFILE LOCATION '$OUTPUT_HDFS/uservisits_aggre';
+CREATE EXTERNAL TABLE uservisits (sourceIP STRING,destURL STRING,visitDate STRING,adRevenue DOUBLE,userAgent STRING,countryCode STRING,languageCode STRING,searchWord STRING,duration INT ) ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS TEXTFILE LOCATION '$INPUT_HDFS/uservisits';
+CREATE EXTERNAL TABLE uservisits_aggre ( sourceIP STRING, sumAdRevenue DOUBLE) STORED AS TEXTFILE LOCATION '$OUTPUT_HDFS/uservisits_aggre';
 INSERT OVERWRITE TABLE uservisits_aggre SELECT sourceIP, SUM(adRevenue) FROM uservisits GROUP BY sourceIP;
 EOF
 }
@@ -409,9 +409,9 @@ set ${REDUCER_CONFIG_NAME}=$NUM_REDS;
 set hive.stats.autogather=false;
 
 
-CREATE EXTERNAL TABLE rankings (pageURL STRING, pageRank INT, avgDuration INT) ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS SEQUENCEFILE LOCATION '$INPUT_HDFS/rankings';
-CREATE EXTERNAL TABLE uservisits_copy (sourceIP STRING,destURL STRING,visitDate STRING,adRevenue DOUBLE,userAgent STRING,countryCode STRING,languageCode STRING,searchWord STRING,duration INT ) ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS SEQUENCEFILE LOCATION '$INPUT_HDFS/uservisits';
-CREATE EXTERNAL TABLE rankings_uservisits_join ( sourceIP STRING, avgPageRank DOUBLE, totalRevenue DOUBLE) STORED AS SEQUENCEFILE LOCATION '$OUTPUT_HDFS/rankings_uservisits_join';
+CREATE EXTERNAL TABLE rankings (pageURL STRING, pageRank INT, avgDuration INT) ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS TEXTFILE LOCATION '$INPUT_HDFS/rankings';
+CREATE EXTERNAL TABLE uservisits_copy (sourceIP STRING,destURL STRING,visitDate STRING,adRevenue DOUBLE,userAgent STRING,countryCode STRING,languageCode STRING,searchWord STRING,duration INT ) ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS TEXTFILE LOCATION '$INPUT_HDFS/uservisits';
+CREATE EXTERNAL TABLE rankings_uservisits_join ( sourceIP STRING, avgPageRank DOUBLE, totalRevenue DOUBLE) STORED AS TEXTFILE LOCATION '$OUTPUT_HDFS/rankings_uservisits_join';
 INSERT OVERWRITE TABLE rankings_uservisits_join SELECT sourceIP, avg(pageRank), sum(adRevenue) as totalRevenue FROM rankings R JOIN (SELECT sourceIP, destURL, adRevenue FROM uservisits_copy UV WHERE (datediff(UV.visitDate, '1999-01-01')>=0 AND datediff(UV.visitDate, '2000-01-01')<=0)) NUV ON (R.pageURL = NUV.destURL) group by sourceIP order by totalRevenue DESC;
 EOF
 }
@@ -430,8 +430,8 @@ set ${REDUCER_CONFIG_NAME}=$NUM_REDS;
 set hive.stats.autogather=false;
 
 
-CREATE EXTERNAL TABLE uservisits (sourceIP STRING,destURL STRING,visitDate STRING,adRevenue DOUBLE,userAgent STRING,countryCode STRING,languageCode STRING,searchWord STRING,duration INT ) ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS SEQUENCEFILE LOCATION '$INPUT_HDFS/uservisits';
-CREATE EXTERNAL TABLE uservisits_copy (sourceIP STRING,destURL STRING,visitDate STRING,adRevenue DOUBLE,userAgent STRING,countryCode STRING,languageCode STRING,searchWord STRING,duration INT ) ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS SEQUENCEFILE LOCATION '$OUTPUT_HDFS/uservisits_copy';
+CREATE EXTERNAL TABLE uservisits (sourceIP STRING,destURL STRING,visitDate STRING,adRevenue DOUBLE,userAgent STRING,countryCode STRING,languageCode STRING,searchWord STRING,duration INT ) ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS TEXTFILE LOCATION '$INPUT_HDFS/uservisits';
+CREATE EXTERNAL TABLE uservisits_copy (sourceIP STRING,destURL STRING,visitDate STRING,adRevenue DOUBLE,userAgent STRING,countryCode STRING,languageCode STRING,searchWord STRING,duration INT ) ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS TEXTFILE LOCATION '$OUTPUT_HDFS/uservisits_copy';
 INSERT OVERWRITE TABLE uservisits_copy SELECT * FROM uservisits;
 EOF
 

--- a/bin/workloads/sql/aggregation/prepare/prepare.sh
+++ b/bin/workloads/sql/aggregation/prepare/prepare.sh
@@ -33,7 +33,7 @@ OPTION="-t hive \
         -r ${NUM_REDS} \
         -p ${PAGES} \
         -v ${USERVISITS} \
-        -o sequence"
+        -o text"
 
 START_TIME=`timestamp`
 run-hadoop-job ${DATATOOLS} HiBench.DataGen ${OPTION}  

--- a/bin/workloads/sql/join/prepare/prepare.sh
+++ b/bin/workloads/sql/join/prepare/prepare.sh
@@ -33,7 +33,7 @@ OPTION="-t hive \
         -r ${NUM_REDS} \
         -p ${PAGES} \
         -v ${USERVISITS} \
-        -o sequence"
+        -o text"
 
 START_TIME=`timestamp`
 run-hadoop-job ${DATATOOLS} HiBench.DataGen ${OPTION}  

--- a/bin/workloads/sql/scan/prepare/prepare.sh
+++ b/bin/workloads/sql/scan/prepare/prepare.sh
@@ -33,7 +33,7 @@ OPTION="-t hive \
         -r ${NUM_REDS} \
         -p ${PAGES} \
         -v ${USERVISITS} \
-        -o sequence"
+        -o text"
 
 START_TIME=`timestamp`
 run-hadoop-job ${DATATOOLS} HiBench.DataGen ${OPTION}  

--- a/sparkbench/common/src/main/scala/org/apache/spark/BaseRangePartitioner.scala
+++ b/sparkbench/common/src/main/scala/org/apache/spark/BaseRangePartitioner.scala
@@ -33,8 +33,8 @@ import scala.util.hashing._
  */
 
 class BaseRangePartitioner [K : Ordering : ClassTag, V]
-      (@transient partitions: Int,
-       @transient rdd: RDD[_ <: Product2[K,V]],
+      (@transient private val partitions: Int,
+       @transient private val rdd: RDD[_ <: Product2[K,V]],
        private var ascending: Boolean = true)
   extends Partitioner {   // Adopted from scala's RangePartitioner
   

--- a/sparkbench/graph/src/main/scala/com/intel/hibench/sparkbench/graph/nweight/Driver.scala
+++ b/sparkbench/graph/src/main/scala/com/intel/hibench/sparkbench/graph/nweight/Driver.scala
@@ -19,7 +19,7 @@ package com.intel.hibench.sparkbench.graph.nweight
 
 import org.apache.spark.{SparkContext, SparkConf}
 import org.apache.spark.storage.StorageLevel
-import org.apache.spark.scheduler.{JobLogger, StatsReportListener}
+import org.apache.spark.scheduler.StatsReportListener
 
 /** 
  * Compute NWeight for Graph G(V, E) as defined below
@@ -74,8 +74,7 @@ object NWeight extends Serializable{
     else
       sparkConf.setAppName("NWeightPregel")
     val sc = new SparkContext(sparkConf)
- 
-    sc.addSparkListener(new JobLogger)
+
     sc.addSparkListener(new StatsReportListener)
 
     if (model.toLowerCase == "graphx") {

--- a/sparkbench/micro/src/main/scala/com/intel/sparkbench/micro/ScalaTeraSort.scala
+++ b/sparkbench/micro/src/main/scala/com/intel/sparkbench/micro/ScalaTeraSort.scala
@@ -20,7 +20,7 @@ package com.intel.hibench.sparkbench.micro
 import com.intel.hibench.sparkbench.common.IOCommon
 import org.apache.hadoop.examples.terasort.{TeraInputFormat, TeraOutputFormat}
 import org.apache.hadoop.io.Text
-import org.apache.spark.SparkContext._
+import org.apache.hadoop.io.BytesWritable
 import org.apache.spark._
 import org.apache.spark.rdd._
 
@@ -30,7 +30,10 @@ object ScalaTeraSort {
   implicit def rddToSampledOrderedRDDFunctions[K: Ordering : ClassTag, V: ClassTag]
   (rdd: RDD[(K, V)]) = new ConfigurableOrderedRDDFunctions[K, V, (K, V)](rdd)
 
-  implicit def ArrayByteOrdering: Ordering[Array[Byte]] = Ordering.fromLessThan{case (a, b)=> a.compareTo(b)<0}
+  implicit def ArrayByteOrdering: Ordering[Array[Byte]] = Ordering.fromLessThan {
+    case (a, b) => (new BytesWritable(a).compareTo(new BytesWritable(b))) < 0
+  }
+
   def main(args: Array[String]) {
     if (args.length != 2) {
       System.err.println(


### PR DESCRIPTION
This is based on @a-roberts's work at #262. Thanks @a-roberts for the efforts. 
We can build this by `mvn clean -Dspark=2.0 package`.

I found another issue when running Sql workloads on Spark 2.0.
"ROW FORMAT DELIMITED is only compatible with `textfile`, not sequence". 

Spark 2.0 doesn't support `ROW FORMAT DELIMITED` for sequence file so I changed the file format to textfile. But there is still problem when running the SQL workloads now.
close #262
