### PR TITLE
Fix spark streaming 2.0 build issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ cache:
   directories:
   - $HOME/.m2
 script:
- # - mvn clean package -q -Dmaven.javadoc.skip=true -Dspark=2.0
+  - mvn clean package -q -Dmaven.javadoc.skip=true -Dspark=2.0
   - mvn clean package -q -Dmaven.javadoc.skip=true
   - sudo -E ./travis/configssh.sh
   - sudo -E ./travis/restart-hadoop-spark.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ jdk:
   - openjdk7
   - oraclejdk8
 install: 
-  - cd src
 before_script:
   - "echo $JAVA_OPTS"
   - "export JAVA_OPTS=-Xmx512m"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk:
   - openjdk7
   - oraclejdk8
-install: 
+install:
 before_script:
   - "echo $JAVA_OPTS"
   - "export JAVA_OPTS=-Xmx512m"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ before_script:
   - "echo $JAVA_OPTS"
   - "export JAVA_OPTS=-Xmx512m"
 env:
-  - SPARK_VERSION=1.5
   - SPARK_VERSION=1.6
 script:
-  - mvn clean package -q -Dmaven.javadoc.skip=true -Dspark${SPARK_VERSION} -DMR2
+  - mvn clean package -q -Dmaven.javadoc.skip=true

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,6 @@
     <mahout.version>0.9</mahout.version>
     <uncommons-maths.version>1.2.2a</uncommons-maths.version>
     <junit.version>3.8.1</junit.version>
-    <spark.version>1.6.0</spark.version>
-    <spark.bin.version>1.6</spark.bin.version>
     <hadoop.mr2.version>2.4.0</hadoop.mr2.version>
     <hadoop.mr1.version>1.2.1</hadoop.mr1.version>
     <scala-maven-plugin.version>3.2.0</scala-maven-plugin.version>

--- a/sparkbench/pom.xml
+++ b/sparkbench/pom.xml
@@ -116,6 +116,19 @@
     </profile>
 
     <profile>
+      <id>defaultSpark</id>
+      <properties>
+        <spark.version>1.6.0</spark.version>
+        <spark.bin.version>1.6</spark.bin.version>
+      </properties>
+      <activation>
+        <property>
+          <name>!spark</name>
+        </property>
+      </activation>
+    </profile>
+
+    <profile>
       <id>spark1.6</id>
       <properties>
         <spark.version>1.6.0</spark.version>

--- a/sparkbench/streaming/pom.xml
+++ b/sparkbench/streaming/pom.xml
@@ -36,6 +36,22 @@
 
   <profiles>
     <profile>
+      <id>defaultSpark</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-streaming-kafka_${scala.binary.version}</artifactId>
+          <version>1.6.0</version>
+        </dependency>
+      </dependencies>
+      <activation>
+        <property>
+          <name>!spark</name>
+        </property>
+      </activation>
+    </profile>
+
+    <profile>
       <id>spark1.6</id>
       <dependencies>
         <dependency>

--- a/sparkbench/streaming/pom.xml
+++ b/sparkbench/streaming/pom.xml
@@ -32,10 +32,41 @@
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming-kafka_${scala.binary.version}</artifactId>
-      <version>${spark.version}</version>
-    </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>spark1.6</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-streaming-kafka_${scala.binary.version}</artifactId>
+          <version>1.6.0</version>
+        </dependency>
+      </dependencies>
+      <activation>
+        <property>
+          <name>spark</name>
+          <value>1.6</value>
+        </property>
+      </activation>
+    </profile>
+
+    <profile>
+      <id>spark2.0</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-streaming-kafka-0-8_2.11</artifactId>
+          <version>2.0.0</version>
+        </dependency>
+      </dependencies>
+      <activation>
+        <property>
+          <name>spark</name>
+          <value>2.0</value>
+        </property>
+      </activation>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
`org.apache.spark:spark-streaming-kafka_2.11:jar:2.0.0`  is not available.
In spark 2.0, the name is `spark-streaming-kafka-0-8_2.11`. 
Closes #353 