### PR TITLE
Change path for examples test jar probing

### DIFF
--- a/bin/functions/load_config.py
+++ b/bin/functions/load_config.py
@@ -421,9 +421,9 @@ def probe_hadoop_examples_test_jars():
         examples_test_jars_candidate_cdh1 = HibenchConf[
             'hibench.hadoop.home'] + "/../../jars/hadoop-mapreduce-client-jobclient*-tests.jar"
         examples_test_jars_candidate_hdp0 = HibenchConf[
-            'hibench.hadoop.home'] + "/../hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient*.jar"
+            'hibench.hadoop.home'] + "/../hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient-tests.jar"
         examples_test_jars_candidate_hdp1 = HibenchConf[
-            'hibench.hadoop.home'] + "/../hadoop-mapreduce/hadoop-mapreduce-client-jobclient*.jar"
+            'hibench.hadoop.home'] + "/../hadoop-mapreduce/hadoop-mapreduce-client-jobclient-tests.jar"
 
         examples_test_jars_candidate_list = [
             examples_test_jars_candidate_apache0,


### PR DESCRIPTION
Previously, CDH users may get multiple files which match the pattern while probing examples test jars, while this PR solve that problem.