### PR TITLE
Enable default support for hibench.yarn.executor.num

### DIFF
--- a/bin/functions/workload-functions.sh
+++ b/bin/functions/workload-functions.sh
@@ -202,7 +202,9 @@ function run-spark-job() {
     if [[ "$SPARK_MASTER" == yarn-* ]]; then
         export_withlog HADOOP_CONF_DIR
         
-        YARN_OPTS="--num-executors ${YARN_NUM_EXECUTORS}"
+        if [[ -n "${YARN_NUM_EXECUTORS:-}" ]]; then
+            YARN_OPTS="${YARN_OPTS} --num-executors ${YARN_NUM_EXECUTORS}"
+        fi
         if [[ -n "${YARN_EXECUTOR_CORES:-}" ]]; then
             YARN_OPTS="${YARN_OPTS} --executor-cores ${YARN_EXECUTOR_CORES}"
        fi


### PR DESCRIPTION
Current implementation assumes the "hibench.yarn.executor.num", that
is, "--num-executors" option, is not empty. The "--num-executors" option
specifies the container num in the whole YARN cluster and it is usually
kept default when submit a application in practice, to make the
application's executors specified by the cluster. Actually, the community
has removed this option in the Spark doc, See
http://spark.apache.org/docs/latest/running-on-yarn.html.
What's more, For porpose of benchmark, we hope the application can
 use up all of the resouces of the cluster.

Changes:
 * bin/functions/workload-functions.sh: append the --num-executors
   option only if the hibench.yarn.executor.num is not none.