### PR TITLE
Switch input data size of "gigantic" and "bigdata"

### DIFF
--- a/conf/workloads/websearch/pagerank.conf
+++ b/conf/workloads/websearch/pagerank.conf
@@ -15,11 +15,11 @@ hibench.pagerank.huge.pages			5000000
 hibench.pagerank.huge.num_iterations		3
 hibench.pagerank.huge.block			0
 hibench.pagerank.huge.block_width		16
-hibench.pagerank.gigantic.pages			50000000
+hibench.pagerank.gigantic.pages			30000000
 hibench.pagerank.gigantic.num_iterations	3
 hibench.pagerank.gigantic.block			0
 hibench.pagerank.gigantic.block_width		16
-hibench.pagerank.bigdata.pages			30000000
+hibench.pagerank.bigdata.pages			50000000
 hibench.pagerank.bigdata.num_iterations		3
 hibench.pagerank.bigdata.block			0
 hibench.pagerank.bigdata.block_width		16


### PR DESCRIPTION
In all other jobs, the input data size of "bigdata" is larger than "gigantic".

However, in this pagerank job, the size of "bigdata" (30000000) is smaller than "gigantic" (50000000).
This commit switches them.