### PR TITLE
Update DenseKMeans.scala

### DIFF
--- a/sparkbench/ml/src/main/scala/com/intel/sparkbench/ml/DenseKMeans.scala
+++ b/sparkbench/ml/src/main/scala/com/intel/sparkbench/ml/DenseKMeans.scala
@@ -81,7 +81,7 @@ object DenseKMeans {
     val conf = new SparkConf().setAppName(s"DenseKMeans with $params")
     val sc = new SparkContext(conf)
 
-    Logger.getRootLogger.setLevel(Level.WARN)
+//    Logger.getRootLogger.setLevel(Level.WARN)
 
     val data = sc.sequenceFile[LongWritable, VectorWritable](params.input)
 


### PR DESCRIPTION
Delete kmeans WARN log level setting to allow more execution info printing in driver.