### PR TITLE
Fix nutchindexing data generation problem, and chagne data scale

### DIFF
--- a/conf/workloads/websearch/nutchindexing.conf
+++ b/conf/workloads/websearch/nutchindexing.conf
@@ -1,9 +1,9 @@
 hibench.nutch.tiny.pages                        25000
-hibench.nutch.small.pages                       1000000
-hibench.nutch.large.pages                       1000000000
-hibench.nutch.huge.pages                        10000000000
-hibench.nutch.gigantic.pages                    100000000000
-hibench.nutch.bigdata.pages                     100000000000
+hibench.nutch.small.pages                       100000
+hibench.nutch.large.pages                       1000000
+hibench.nutch.huge.pages                        5000000
+hibench.nutch.gigantic.pages                    10000000
+hibench.nutch.bigdata.pages                     20000000
 
 hibench.nutch.pages                     ${hibench.nutch.${hibench.scale.profile}.pages}
 hibench.nutch.base.hdfs                 ${hibench.hdfs.data.dir}/Nutchindexing


### PR DESCRIPTION
The old scale of nutchindexing is too large that its prepare job may be stuck. Now, generating large, gigantic, bigdata data needs 10 mins, 20 mins, 30 mins respectively, which is executable. The map and shuffle parallelism is 490 for the above tests. Increase the number of parallelism will decrease memory pressure for each task, but will slow down the total processing time.

Moreover, if the prepare job is stuck, one of the reasons is that there is no enough java heap space. To solve this problem, set larger space of mapred.child.java.opts in mapred-site.xml of Hadoop configuration.