### PR TITLE
Make the hint more specific

### DIFF
--- a/bin/functions/load_config.py
+++ b/bin/functions/load_config.py
@@ -148,7 +148,9 @@ def read_file_content(filepath):
 
 def parse_conf(conf_root, workload_config_file):
     conf_files = sorted(glob.glob(conf_root + "/*.conf")) + sorted(glob.glob(workload_config_file))
-
+    # load hibench.conf first
+    conf_files.insert(0, conf_files.pop(
+        [i for i, filename in enumerate(conf_files) if filename.endswith("hibench.conf")][0]))
     # load values from conf files
     for filename in conf_files:
         log("Parsing conf: %s" % filename)

--- a/bin/functions/load_config.py
+++ b/bin/functions/load_config.py
@@ -525,7 +525,7 @@ def probe_masters_slaves_by_Yarn():
         else:
             assert 0, "Unknown resourcemanager, please check `hibench.hadoop.configure.dir` and \"yarn-site.xml\" file"
     except Exception as e:
-        assert 0, "Get workers from yarn-site.xml page failed, reason:%s\nplease set `hibench.masters.hostnames` and `hibench.slaves.hostnames` manually" % e
+        assert 0, "Get workers from yarn-site.xml page failed, reason:%s\nplease set `hibench.masters.hostnames` and `hibench.slaves.hostnames` in hibench.conf manually" % e
 
 
 def probe_masters_slaves_hostnames():


### PR DESCRIPTION
Currently, the conf name probing is in alphabetic order. So it'll be `hadoop.conf`, `hibench.conf`, and then `spark.conf`.

When HiBench asks the user to specify `hibench.masters.hostnames` manually, if he/she doesn't set it in `hibench.conf`, the manual config won't work because it'll be override by that in another 2 confs and it confuses. 

So we should make the hint clearer.