### PR TITLE
Add RF workload

### DIFF
--- a/bin/functions/hibench_prop_env_mapping.py
+++ b/bin/functions/hibench_prop_env_mapping.py
@@ -102,6 +102,10 @@ HiBenchEnvPropMapping=dict(
     NUM_ITERATIONS_ALS="hibench.als.num_iterations",
     LAMBDA="hibench.als.Lambda",
     KYRO="hibench.als.kyro",
+    # For Random Forest
+    NUM_EXAMPLES_RF="hibench.rf.examples",
+    NUM_FEATURES_RF="hibench.rf.features",
+    NUMTREES="hibench.rf.numTrees",
     # For Pagerank
     PAGERANK_BASE_HDFS="hibench.pagerank.base.hdfs",
     PAGERANK_INPUT="hibench.pagerank.dir.name.input",

--- a/bin/run_all.sh
+++ b/bin/run_all.sh
@@ -58,6 +58,9 @@ for benchmark in `cat $root_dir/conf/benchmarks.lst`; do
 	if [ $benchmark == "ml/als" ] && [ $framework == "hadoop" ]; then
 	    continue
 	fi
+        if [ $benchmark == "ml/rf" ] && [ $framework == "hadoop" ]; then
+            continue
+        fi
         
 	echo -e "${UYellow}${BYellow}Run ${Yellow}${UYellow}${benchmark}/${framework}${Color_Off}"
 	echo -e "${BCyan}Exec script: ${Cyan}$WORKLOAD/${framework}/run.sh${Color_Off}"

--- a/bin/workloads/ml/rf/prepare/prepare.sh
+++ b/bin/workloads/ml/rf/prepare/prepare.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+current_dir=`dirname "$0"`
+current_dir=`cd "$current_dir"; pwd`
+root_dir=${current_dir}/../../../../../
+workload_config=${root_dir}/conf/workloads/ml/rf.conf
+. "${root_dir}/bin/functions/load_bench_config.sh"
+
+enter_bench RandomForestDataPrepare ${workload_config} ${current_dir}
+show_bannar start
+
+rmr_hdfs $INPUT_HDFS || true
+START_TIME=`timestamp`
+
+run_spark_job com.intel.hibench.sparkbench.ml.RandomForestDataGenerator $INPUT_HDFS $NUM_EXAMPLES_RF $NUM_FEATURES_RF
+
+END_TIME=`timestamp`
+
+show_bannar finish
+leave_bench
+

--- a/bin/workloads/ml/rf/spark/run.sh
+++ b/bin/workloads/ml/rf/spark/run.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+current_dir=`dirname "$0"`
+current_dir=`cd "$current_dir"; pwd`
+root_dir=${current_dir}/../../../../../
+workload_config=${root_dir}/conf/workloads/ml/rf.conf
+. "${root_dir}/bin/functions/load_bench_config.sh"
+
+enter_bench RandomForest ${workload_config} ${current_dir}
+show_bannar start
+
+rmr_hdfs $OUTPUT_HDFS || true
+
+SIZE=`dir_size $INPUT_HDFS`
+START_TIME=`timestamp`
+run_spark_job com.intel.hibench.sparkbench.ml.RandomForestClassification ${INPUT_HDFS} ${NUMTREES}
+END_TIME=`timestamp`
+
+gen_report ${START_TIME} ${END_TIME} ${SIZE}
+show_bannar finish
+leave_bench

--- a/conf/benchmarks.lst
+++ b/conf/benchmarks.lst
@@ -15,5 +15,6 @@ ml.bayes
 ml.kmeans
 ml.lr
 ml.als
+ml.rf
 
 graph.nweight

--- a/conf/hibench.conf
+++ b/conf/hibench.conf
@@ -1,12 +1,12 @@
 # Data scale profile. Available value is tiny, small, large, huge, gigantic and bigdata.
 # The definition of these profiles can be found in the workload's conf file i.e. conf/workloads/micro/wordcount.conf
-hibench.scale.profile                 tiny
+hibench.scale.profile                 bigdata
 
 # Mapper number in hadoop, partition number in Spark
-hibench.default.map.parallelism         8
+hibench.default.map.parallelism         92
 
 # Reducer nubmer in hadoop, shuffle partition number in Spark
-hibench.default.shuffle.parallelism     8
+hibench.default.shuffle.parallelism     92
 
 
 #======================================================

--- a/conf/hibench.conf
+++ b/conf/hibench.conf
@@ -1,12 +1,12 @@
 # Data scale profile. Available value is tiny, small, large, huge, gigantic and bigdata.
 # The definition of these profiles can be found in the workload's conf file i.e. conf/workloads/micro/wordcount.conf
-hibench.scale.profile                 bigdata
+hibench.scale.profile                 tiny
 
 # Mapper number in hadoop, partition number in Spark
-hibench.default.map.parallelism         92
+hibench.default.map.parallelism         8
 
 # Reducer nubmer in hadoop, shuffle partition number in Spark
-hibench.default.shuffle.parallelism     92
+hibench.default.shuffle.parallelism     8
 
 
 #======================================================

--- a/conf/workloads/ml/rf.conf
+++ b/conf/workloads/ml/rf.conf
@@ -4,12 +4,12 @@ hibench.rf.small.examples                       100
 hibench.rf.small.features                       500
 hibench.rf.large.examples                       1000
 hibench.rf.large.features                       1000
-hibench.rf.huge.examples                        1000
-hibench.rf.huge.features                        2000
-hibench.rf.gigantic.examples                    1000
-hibench.rf.gigantic.features                    5000
-hibench.rf.bigdata.examples                     1000
-hibench.rf.bigdata.features                     10000
+hibench.rf.huge.examples                        10000
+hibench.rf.huge.features                        200000
+hibench.rf.gigantic.examples                    10000
+hibench.rf.gigantic.features                    300000
+hibench.rf.bigdata.examples                     20000
+hibench.rf.bigdata.features                     220000
 
 
 hibench.rf.examples                     ${hibench.rf.${hibench.scale.profile}.examples}

--- a/conf/workloads/ml/rf.conf
+++ b/conf/workloads/ml/rf.conf
@@ -1,0 +1,21 @@
+hibench.rf.tiny.examples                        10
+hibench.rf.tiny.features                        100
+hibench.rf.small.examples                       100
+hibench.rf.small.features                       500
+hibench.rf.large.examples                       1000
+hibench.rf.large.features                       1000
+hibench.rf.huge.examples                        1000
+hibench.rf.huge.features                        2000
+hibench.rf.gigantic.examples                    1000
+hibench.rf.gigantic.features                    5000
+hibench.rf.bigdata.examples                     1000
+hibench.rf.bigdata.features                     10000
+
+
+hibench.rf.examples                     ${hibench.rf.${hibench.scale.profile}.examples}
+hibench.rf.features                     ${hibench.rf.${hibench.scale.profile}.features}
+hibench.rf.partitions                   ${hibench.default.map.parallelism}
+hibench.rf.numTrees                     100
+
+hibench.workload.input                  ${hibench.hdfs.data.dir}/RF/Input
+hibench.workload.output                 ${hibench.hdfs.data.dir}/RF/Output

--- a/conf/workloads/ml/rf.info
+++ b/conf/workloads/ml/rf.info
@@ -1,0 +1,7 @@
+Spark job
+            tiny   small   large   huge   gigantic   bigdata
+Time cost   9s     10s     13s     11m    17m        28m
+
+Num. of workers             2
+Cores(used/total)           46/48
+Mem                         180G

--- a/conf/workloads/ml/rf.info
+++ b/conf/workloads/ml/rf.info
@@ -1,6 +1,7 @@
 Spark job
             tiny   small   large   huge   gigantic   bigdata
 Time cost   9s     10s     13s     11m    17m        28m
+Size        19.4K  427.4K  7.7M    14.9G  22.4G      32.8G
 
 Num. of workers             2
 Cores(used/total)           46/48

--- a/sparkbench/ml/src/main/scala/com/intel/sparkbench/ml/RandomForestClassification.scala
+++ b/sparkbench/ml/src/main/scala/com/intel/sparkbench/ml/RandomForestClassification.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.hibench.sparkbench.ml
+
+import com.intel.hibench.sparkbench.common.IOCommon
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.mllib.tree.RandomForest
+import org.apache.spark.mllib.tree.model.RandomForestModel
+import org.apache.spark.mllib.util.MLUtils
+import org.apache.spark.rdd.RDD
+import org.apache.spark.mllib.regression.LabeledPoint
+
+object RandomForestClassification {
+
+  def main(args: Array[String]): Unit = {
+    var inputPath = ""
+    var numTrees = 3
+
+    if (args.length == 2) {
+      inputPath = args(0)
+      numTrees = args(1).toInt
+    }
+
+    val conf = new SparkConf().setAppName("RandomForestClassification")
+    val sc = new SparkContext(conf)
+
+    // $example on$
+    // Load and parse the data file.
+    val data: RDD[LabeledPoint] = sc.objectFile(inputPath)
+
+    // Split the data into training and test sets (30% held out for testing)
+    val splits = data.randomSplit(Array(0.7, 0.3))
+    val (trainingData, testData) = (splits(0), splits(1))
+
+    // Train a RandomForest model.
+    // Empty categoricalFeaturesInfo indicates all features are continuous.
+    val numClasses = 2
+    val categoricalFeaturesInfo = Map[Int, Int]()
+    val featureSubsetStrategy = "auto" // Let the algorithm choose.
+    val impurity = "gini"
+    val maxDepth = 4
+    val maxBins = 32
+
+    val model = RandomForest.trainClassifier(trainingData, numClasses, categoricalFeaturesInfo,
+      numTrees, featureSubsetStrategy, impurity, maxDepth, maxBins)
+
+    // Evaluate model on test instances and compute test error
+    val labelAndPreds = testData.map { point =>
+      val prediction = model.predict(point.features)
+      (point.label, prediction)
+    }
+    val testErr = labelAndPreds.filter(r => r._1 != r._2).count.toDouble / testData.count()
+    println("Test Error = " + testErr)
+    println("Learned classification forest model:\n" + model.toDebugString)
+
+    sc.stop()
+  }
+}

--- a/sparkbench/ml/src/main/scala/com/intel/sparkbench/ml/RandomForestDataGenerator.scala
+++ b/sparkbench/ml/src/main/scala/com/intel/sparkbench/ml/RandomForestDataGenerator.scala
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.hibench.sparkbench.ml
+
+import com.intel.hibench.sparkbench.common.IOCommon
+
+import scala.util.Random
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.annotation.{DeveloperApi, Since}
+import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.mllib.regression.LabeledPoint
+import org.apache.spark.rdd.RDD
+
+/**
+ * :: DeveloperApi ::
+ * Generate test data for LogisticRegression. This class chooses positive labels
+ * with probability `probOne` and scales features for positive examples by `eps`.
+ */
+object RandomForestDataGenerator {
+
+  /**
+   * Generate an RDD containing test data for LogisticRegression.
+   *
+   * @param sc SparkContext to use for creating the RDD.
+   * @param nexamples Number of examples that will be contained in the RDD.
+   * @param nfeatures Number of features to generate for each example.
+   * @param eps Epsilon factor by which positive examples are scaled.
+   * @param nparts Number of partitions of the generated RDD. Default value is 2.
+   * @param probOne Probability that a label is 1 (and not 0). Default value is 0.5.
+   */
+  def generateLogisticRDD(
+    sc: SparkContext,
+    nexamples: Int,
+    nfeatures: Int,
+    eps: Double,
+    nparts: Int = 2,
+    probOne: Double = 0.5): RDD[LabeledPoint] = {
+    val data = sc.parallelize(0 until nexamples, nparts).map { idx =>
+      val rnd = new Random(42 + idx)
+
+      val y = if (idx % 2 == 0) 0.0 else 1.0
+      val x = Array.fill[Double](nfeatures) {
+        rnd.nextGaussian() + (y * eps)
+      }
+      LabeledPoint(y, Vectors.dense(x))
+    }
+    data
+  }
+
+  def main(args: Array[String]) {
+    val conf = new SparkConf().setAppName("RandomForestDataGenerator")
+    val sc = new SparkContext(conf)
+
+    var outputPath = ""
+    var numExamples: Int = 200000
+    var numFeatures: Int = 20
+    val parallel = sc.getConf.getInt("spark.default.parallelism", sc.defaultParallelism)
+    val numPartitions = IOCommon.getProperty("hibench.default.shuffle.parallelism")
+      .getOrElse((parallel / 2).toString).toInt
+    val eps = 3
+
+    if (args.length == 3) {
+      outputPath = args(0)
+      numExamples = args(1).toInt
+      numFeatures = args(2).toInt
+      println(s"Output Path: $outputPath")
+      println(s"Num of Examples: $numExamples")
+      println(s"Num of Features: $numFeatures")
+    } else {
+      System.err.println(
+        s"Usage: $RandomForestDataGenerator <OUTPUT_PATH> <NUM_EXAMPLES> <NUM_FEATURES>"
+      )
+      System.exit(1)
+    }
+
+    val data = generateLogisticRDD(sc, numExamples, numFeatures, eps, numPartitions)
+
+    data.saveAsObjectFile(outputPath)
+
+    sc.stop()
+  }
+}

--- a/travis/benchmarks.lst
+++ b/travis/benchmarks.lst
@@ -1,5 +1,6 @@
 micro.sort
 ml.bayes
+ml.rf
 websearch.nutchindexing
 sql.scan
 graph.nweight


### PR DESCRIPTION
Random Forest (RF) is a tree algorithm in Spark mllib package. Its workload is added and its data format is RDD[LabeledPoint]. The data scale is set with the time costs and the test environment information shown below. This environment information is also added in this PR under conf/workloads/ml/rf.info.

Spark job
                  tiny   small   large   huge   gigantic   bigdata
Time cost   9s     10s     13s      11m    17m         28m

Num. of workers             2
Cores(used/total)           46/48
Mem                              180G
