### PR TITLE
fix sleep time errors for hadoop sleep test

### DIFF
--- a/bin/workloads/micro/sleep/hadoop/run.sh
+++ b/bin/workloads/micro/sleep/hadoop/run.sh
@@ -24,7 +24,7 @@ enter_bench HadoopSleep ${workload_config} ${current_dir}
 show_bannar start
 
 START_TIME=`timestamp`
-run_hadoop_job $HADOOP_SLEEP_JAR sleep -m $NUM_MAPS -r $NUM_REDS -mt $MAP_SLEEP_TIME -rt $RED_SLEEP_TIME
+run_hadoop_job $HADOOP_SLEEP_JAR sleep -m $NUM_MAPS -r $NUM_REDS -mt $(($MAP_SLEEP_TIME*1000)) -rt $(($RED_SLEEP_TIME*1000))
 END_TIME=`timestamp`
 SIZE="0"
 

--- a/bin/workloads/micro/sleep/hadoop/run.sh
+++ b/bin/workloads/micro/sleep/hadoop/run.sh
@@ -24,7 +24,7 @@ enter_bench HadoopSleep ${workload_config} ${current_dir}
 show_bannar start
 
 START_TIME=`timestamp`
-run_hadoop_job $HADOOP_SLEEP_JAR sleep -m $NUM_MAPS -r $NUM_REDS -mt $MAP_SLEEP_TIME -mr $RED_SLEEP_TIME
+run_hadoop_job $HADOOP_SLEEP_JAR sleep -m $NUM_MAPS -r $NUM_REDS -mt $MAP_SLEEP_TIME -rt $RED_SLEEP_TIME
 END_TIME=`timestamp`
 SIZE="0"
 


### PR DESCRIPTION
In hadoop-mapreduce-client-jobclient-2.8.4-tests.jar (or other versions), input parameter for ReduceSleepTime should be 'rt', not 'mt'. Also, map and reduce sleep times' unit is millisecond, not second.

See this usage as well:
SleepJob [-m numMapper] [-r numReducer] [-mt mapSleepTime (msec)] [-rt reduceSleepTime (msec)] [-recordt recordSleepTime (msec)]

Cross-checked the source code as well:
https://github.com/apache/hadoop/blob/trunk/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/SleepJob.java